### PR TITLE
Allcontrib

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,10 +29,11 @@ jobs:
         with:
           extra-packages: |
             github::ropensci-review-tools/pkgcheck@main
+            github::ropenscilabs/allcontributors
+            github::assignUser/octolog
             any::here
       - name: Update README.md
-        run: source("R/insert-inputs.R")
-        shell: Rscript {0}
+        run: make
       - name: Commit changes
         run: |
           git config user.name  "Github Actions"
@@ -44,8 +45,6 @@ jobs:
     needs: update-readme
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    outputs:
-      update_readme: ${{ steps.check.outputs.update_readme}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up QEMU
@@ -82,11 +81,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Check if action.yaml changed
-        id: check
-        run: >
-          echo "::set-output name=update_readme::
-          `git show --name-only --oneline |
-            grep -c action.yaml |
-            cat`"
-        shell: bash

--- a/README.md
+++ b/README.md
@@ -119,3 +119,36 @@ This default behaviour protects your repository from malicious use of `pull_requ
 ## Versions
 
 This action has no version tags, as you will always want to pass the newest {pgkcheck} available.
+
+## Contributors
+
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+All contributions to this project are gratefully acknowledged using the [`allcontributors` package](https://github.com/ropenscilabs/allcontributors) following the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
+
+<table>
+
+<tr>
+<td align="center">
+<a href="https://github.com/assignUser">
+<img src="https://avatars.githubusercontent.com/u/16141871?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ropensci-review-tools/pkgcheck-action/commits?author=assignUser">assignUser</a>
+</td>
+<td align="center">
+<a href="https://github.com/mpadge">
+<img src="https://avatars.githubusercontent.com/u/6697851?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ropensci-review-tools/pkgcheck-action/commits?author=mpadge">mpadge</a>
+</td>
+</tr>
+
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+

--- a/makefile
+++ b/makefile
@@ -1,6 +1,9 @@
 LFILE = R/insert-inputs
 
-all: insert
+all: contrib insert
+
+contrib:
+	Rscript -e "allcontributors::add_contributors()"
 
 insert: $(LFILE).R
 	Rscript $(LFILE).R


### PR DESCRIPTION
@assignUser This adds an "all contributors" footer to the README, like [this example from `pkgcheck`, which now features your contributions](https://github.com/ropensci-review-tools/pkgcheck#contributors).