### PR TITLE
Use pak stable, no update

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,4 +83,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          #cache-from: type=gha
+          #cache-to: type=gha,mode=max
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          #cache-from: type=gha
-          #cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ghcr.io/ropensci-review-tools/pkgcheck:latest
 LABEL maintainer="Jacob Wujciak-Jens <jacob@wujciak.de>"
 
-ENV R_REMOTES_UPGRADE "always"
 ENV NOT_CRAN "true"
 
 COPY R/check.R /check.R

--- a/R/check.R
+++ b/R/check.R
@@ -3,7 +3,6 @@ library(magrittr)
 library(octolog)
 enable_github_colors()
 
-pak::pak_update()
 octo_start_group("Install dependencies")
 
 file_dir <- fs::dir_create(".pkgcheck")

--- a/R/install.R
+++ b/R/install.R
@@ -1,5 +1,9 @@
+cat("::group::Install pak", sep = "\n")
 devtools::install_github("r-lib/pak@1311b92dfcb35c6596070cb80211179dcb7d1a5d")
+pak:::create_dev_lib()
+cat("::endgroup::", sep = "\n")
 
+cat("::group::Install dependencies", sep = "\n")
 dir.create("lckfile", showWarnings = FALSE)
 Sys.setenv("PKGCACHE_HTTP_VERSION" = "2")
 
@@ -18,6 +22,7 @@ pak::lockfile_create(
 )
 
 pak::lockfile_install("lckfile/pkg.lock")
+cat("::endgroup::", sep = "\n")
 
 if (packageVersion("sessioninfo") >= "1.2.1") {
     sessioninfo::session_info(pkgs = "installed", include_base = TRUE)

--- a/R/install.R
+++ b/R/install.R
@@ -1,9 +1,9 @@
-cat("::group::Install pak", sep = "\n")
-devtools::install_github("r-lib/pak@1311b92dfcb35c6596070cb80211179dcb7d1a5d")
-pak:::create_dev_lib()
-cat("::endgroup::", sep = "\n")
 
-cat("::group::Install dependencies", sep = "\n")
+remotes::install_github("r-lib/pak@1311b92dfcb35c6596070cb80211179dcb7d1a5d", dependencies = TRUE)
+pak:::create_dev_lib()
+
+
+
 dir.create("lckfile", showWarnings = FALSE)
 Sys.setenv("PKGCACHE_HTTP_VERSION" = "2")
 
@@ -22,7 +22,7 @@ pak::lockfile_create(
 )
 
 pak::lockfile_install("lckfile/pkg.lock")
-cat("::endgroup::", sep = "\n")
+
 
 if (packageVersion("sessioninfo") >= "1.2.1") {
     sessioninfo::session_info(pkgs = "installed", include_base = TRUE)

--- a/R/install.R
+++ b/R/install.R
@@ -1,7 +1,12 @@
 
-remotes::install_github("r-lib/pak", dependencies = TRUE)
-pak:::create_dev_lib()
-
+install.packages("pak",
+    repos = sprintf(
+        "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+        .Platform$pkgType,
+        R.Version()$os, R.Version()$arch
+    ),
+    dependencies = TRUE
+)
 
 
 dir.create("lckfile", showWarnings = FALSE)

--- a/R/install.R
+++ b/R/install.R
@@ -1,5 +1,5 @@
 
-remotes::install_github("r-lib/pak@1311b92dfcb35c6596070cb80211179dcb7d1a5d", dependencies = TRUE)
+remotes::install_github("r-lib/pak", dependencies = TRUE)
 pak:::create_dev_lib()
 
 

--- a/R/install.R
+++ b/R/install.R
@@ -1,5 +1,5 @@
 
-install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
+install.packages("pak")
 dir.create("lckfile", showWarnings = FALSE)
 Sys.setenv("PKGCACHE_HTTP_VERSION" = "2")
 

--- a/R/install.R
+++ b/R/install.R
@@ -1,5 +1,5 @@
+devtools::install_github("r-lib/pak@1311b92dfcb35c6596070cb80211179dcb7d1a5d")
 
-install.packages("pak")
 dir.create("lckfile", showWarnings = FALSE)
 Sys.setenv("PKGCACHE_HTTP_VERSION" = "2")
 

--- a/R/install.R
+++ b/R/install.R
@@ -1,4 +1,5 @@
-install.packages("pak", repos = "https://r-lib.github.io/p/pak/devel/")
+
+install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
 dir.create("lckfile", showWarnings = FALSE)
 Sys.setenv("PKGCACHE_HTTP_VERSION" = "2")
 
@@ -22,5 +23,8 @@ if (packageVersion("sessioninfo") >= "1.2.1") {
     sessioninfo::session_info(pkgs = "installed", include_base = TRUE)
 } else {
     options(width = 200)
-    sessioninfo::session_info(rownames(installed.packages()), include_base = TRUE)
+    sessioninfo::session_info(
+        rownames(installed.packages()),
+        include_base = TRUE
+    )
 }

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
       with:
         ref: "${{ inputs.ref }}"
         fetch-depth: 0
-    - uses: docker://ghcr.io/ropensci-review-tools/pkgcheck-action:latest
+    - uses: docker://ghcr.io/ropensci-review-tools/pkgcheck-action:fix-pak
       env:
         GITHUB_TOKEN: ${{ github.token }}
       id: pkgcheck

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
       with:
         ref: "${{ inputs.ref }}"
         fetch-depth: 0
-    - uses: docker://ghcr.io/ropensci-review-tools/pkgcheck-action:fix-pak
+    - uses: docker://ghcr.io/ropensci-review-tools/pkgcheck-action:latest
       env:
         GITHUB_TOKEN: ${{ github.token }}
       id: pkgcheck


### PR DESCRIPTION
`pak::pak_update` is currently broken (https://github.com/r-lib/pak/issues/369)
So we use a stable version with no updates.