### PR TITLE
rename pkgcheck fn

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -47,7 +47,7 @@ fs::file_copy("full.md", file_dir) %>%
     octo_set_output("full_md")
 
 
-render_markdown(md, FALSE) %>%
+render_md2html(md, FALSE) %>%
     fs::file_copy(file_dir) %>%
     octo_set_output("results")
 


### PR DESCRIPTION
@assignUser This change is definitely needed. I had to rename `pkgcheck::render_markdown()`, which is used here. It's now called `pkgcheck::render_md2html()`. Can you please do an update and release after merging this? Thanks!