### PR TITLE
do not render md -> html for #54

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -32,7 +32,7 @@ check <- pkgcheck()
 fs::file_copy(check$info$network_file, file_dir) %>%
     octo_set_output("visnet_path")
 
-md <- checks_to_markdown(check)
+md <- checks_to_markdown(check, render = FALSE)
 s_break <- md %>%
     grep("---", .) %>%
     .[[1]]
@@ -45,11 +45,6 @@ fs::file_copy("summary.md", file_dir) %>%
 writeLines(md, "full.md")
 fs::file_copy("full.md", file_dir) %>%
     octo_set_output("full_md")
-
-
-render_md2html(md, FALSE) %>%
-    fs::file_copy(file_dir) %>%
-    octo_set_output("results")
 
 octo_end_group()
 

--- a/action.yaml
+++ b/action.yaml
@@ -47,10 +47,6 @@ runs:
       with:
         name: visual-network
         path: "${{ steps.pkgcheck.outputs.visnet_path }}"
-    - uses: actions/upload-artifact@v4
-      with:
-        name: results
-        path: "${{ steps.pkgcheck.outputs.results }}"
     - name: Check for active issue
       id: get-id
       if: ${{ inputs.post-to-issue}}


### PR DESCRIPTION
@assignUser I am utterly unable to reproduce #54 locally in any way, including in what should be a perfect local copy of the GitHub runner. This PR is a work-around which just switches off the rendering, and so won't call `pandoc` at all. You had only used the rendered version as input to `octo_set_output("results")`, but that's just a HTML-rendered version of the `.md` that we already have anyway, so it's not really needed here at all, right?