### PR TITLE
only copy network file on exists

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -29,8 +29,11 @@ octo_start_group("Running Pkgcheck...")
 pkgstats::ctags_install(sudo = TRUE)
 
 check <- pkgcheck()
-fs::file_copy(check$info$network_file, file_dir) %>%
-    octo_set_output("visnet_path")
+
+if (fs::file_exists (check$info$network_file)) {
+    fs::file_copy(check$info$network_file, file_dir) %>%
+        octo_set_output("visnet_path")
+}
 
 md <- checks_to_markdown(check, render = FALSE)
 s_break <- md %>%


### PR DESCRIPTION
@assignUser Context in [this failed run](https://github.com/ropensci-review-tools/pkgcheck/actions/runs/16442384648/job/46466022929), because I guess the main `pkgcheck` call is being run as a separate process, and so cleaned up afterwards? Although not always, so dunno, really. Anyway, it certainly doesn't happen all the time, and so where the expected file does exist, it'll still be uploaded as an artifact, and in cases where it's gone, the run will still complete. Feel free to merge if you approve. Thanks!